### PR TITLE
fix: watch buffers instead of editors

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,7 @@
 {CompositeDisposable} = require 'atom'
 {readCsonFile} = require './promise-helper'
 path = require 'path'
+fs = require 'fs'
 
 toUnix = (path) -> path.replace /\\/g, '/'
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -83,6 +83,9 @@ module.exports =
           @buffers.delete buffer
           subs.dispose()
 
+        # Stop watching when all editors of this file are closed.
+        subs.add buffer.onDidDestroy stopWatching
+
         # Stop watching when the package is deactivated.
         pack = atom.packages.getActivePackage packName
         subs.add packSub = pack.onDidDeactivate stopWatching

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,17 +1,8 @@
+{CompositeDisposable} = require 'atom'
 {readCsonFile} = require './promise-helper'
 path = require 'path'
-fs = require 'fs'
 
 toUnix = (path) -> path.replace /\\/g, '/'
-
-getPackageNameByFilePath = (currentPath) ->
-  rootPath = path.resolve currentPath, '../..'
-  for pack in atom.packages.getActivePackages()
-    stats = fs.lstatSync pack.path
-    packPath = if stats.isSymbolicLink then fs.realpathSync pack.path else pack.path
-    if packPath is rootPath
-      return pack.name
-  ""
 
 module.exports =
 
@@ -37,47 +28,86 @@ module.exports =
 
   configSub: null
   editorSub: null
-  watching: Object.create null
+  buffers: new Map
   debug: false
 
   activate: (state) ->
     return if atom.inSpecMode() or not atom.inDevMode()
 
     @configSub = atom.config.observe 'grammar-live-reload.enabled', (enabled) =>
-      return @editorSub?.dispose() unless enabled
 
-      reload = @reload.bind this
+      unless enabled
+        @editorSub?.dispose()
+        @editorSub = null
+        @buffers.forEach (subs) -> subs.dispose()
+        @buffers.clear()
+        return
+
+      resolveSymlink = (filePath) ->
+        stats = fs.lstatSync filePath
+        if stats.isSymbolicLink()
+        then fs.realpathSync filePath
+        else filePath
+
+      resolvePackageName = (grammarPath) ->
+        packPath = resolveSymlink path.resolve grammarPath, '../..'
+        for pack in atom.packages.getActivePackages()
+          return pack.name if packPath is resolveSymlink pack.path
+
+      isGrammarPath = (filePath) ->
+        grammarRE = atom.config.get 'grammar-live-reload.grammarRE'
+        grammarRE = new RegExp grammarRE.replace /\//g, '\\/'
+        grammarRE.test toUnix filePath
+
       @editorSub = atom.workspace.observeTextEditors (editor) =>
-        grammarRE = ///#{atom.config.get 'grammar-live-reload.grammarRE'}///
-        if grammarRE.test toUnix filePath = editor.getPath()
+        return if @buffers.has buffer = editor.getBuffer()
 
-          # See if the file's package is blacklisted.
-          if blacklist = atom.config.get 'grammar-live-reload.blacklist'
+        filePath = buffer.getPath()
+        unless packName = resolvePackageName filePath
+          @debug and console.log 'Grammar is not active: ' + filePath
+          return
 
-            unless packName = getPackageNameByFilePath filePath
-              debug and console.log 'Package does not exist: ' + filePath
-              return
+        # Check if the user defined a blacklist.
+        if blacklist = atom.config.get 'grammar-live-reload.blacklist'
+          # Support both comma-separated and space-separated names.
+          if blacklist.split(/(?:,\s*)|\s+/g).indexOf(packName) >= 0
+            @debug and console.log 'Grammar is on blacklist: ' + packName
+            return
 
-            # Support both comma-separated and space-separated names.
-            for name in blacklist.split /(?:,\s*)|\s+/g
-              if name is packName
-                debug and console.log 'Package reload was prevented: ' + packName
-                return
+        subs = new CompositeDisposable
 
-          # Avoid watching the same file twice.
-          unless @watching[filePath]
-            @debug and console.log 'Watching file for changes: ' + filePath
-            @watching[filePath] = true
-            editor.onDidSave reload
-            editor.onDidDestroy =>
-              delete @watching[filePath]
+        # Stop watching when the file is deleted.
+        subs.add buffer.onDidDelete stopWatching = =>
+          @debug and console.log 'Stopped watching: ' + filePath
+          @buffers.delete buffer
+          subs.dispose()
 
-  reload: (event) ->
+        # Stop watching when the package is deactivated.
+        pack = atom.packages.getActivePackage packName
+        subs.add packSub = pack.onDidDeactivate stopWatching
+
+        subs.add buffer.onDidSave =>
+          packSub.dispose()
+          subs.remove packSub
+          @reloadGrammar(packName).then ->
+            pack = atom.packages.getActivePackage packName
+            subs.add packSub = pack.onDidDeactivate stopWatching
+
+        subs.add buffer.onDidChangePath (newPath) =>
+          @debug and console.log 'Stopped watching: ' + filePath
+          if isGrammarPath newPath
+            @debug and console.log 'Started watching: ' + newPath
+            filePath = newPath
+          else
+            @buffers.delete buffer
+            subs.dispose()
+
+        @debug and console.log 'Started watching: ' + filePath
+        @buffers.set buffer, subs
+        return
+
+  reloadGrammar: (packName) ->
     {debug} = this
-
-    unless packName = getPackageNameByFilePath event.path
-      debug and console.log 'Package does not exist: ' + event.path
-      return
 
     # Unload the grammar package.
     debug and console.log 'Deactivating package: ' + packName
@@ -97,11 +127,10 @@ module.exports =
           grammars[grammar.scopeName] = grammar
 
         for editor in atom.workspace.getTextEditors()
-          do (editor) ->
-            grammar = editor.getGrammar()
-            if grammar.packageName is packName
-              debug and console.log 'Updating grammar for editor: ', editor
-              editor.setGrammar grammars[grammar.scopeName]
+          grammar = editor.getGrammar()
+          if grammar.packageName is packName
+            debug and console.log 'Updating grammar for editor: ', editor
+            editor.setGrammar grammars[grammar.scopeName]
 
       # Report any errors.
       .catch console.error

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,7 +64,7 @@ module.exports =
         return if @buffers.has buffer = editor.getBuffer()
 
         filePath = buffer.getPath()
-        return unless isGrammarPath filePath
+        return unless filePath and isGrammarPath filePath
 
         unless packName = resolvePackageName filePath
           @debug and console.log 'Grammar is not active: ' + filePath

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,6 +64,8 @@ module.exports =
         return if @buffers.has buffer = editor.getBuffer()
 
         filePath = buffer.getPath()
+        return unless isGrammarPath filePath
+
         unless packName = resolvePackageName filePath
           @debug and console.log 'Grammar is not active: ' + filePath
           return


### PR DESCRIPTION
Watching `TextBuffer` objects instead of `TextEditor` objects worksbetter, because editors of the same file share the same buffer.
Also, the `onDidDestroy` listener was broken, because it didn't look for editors of the same path before mutating the `watching` object. The first solution I thought of was to keep track of how many editors are open per watched file, but that also meant attaching `onDidDestroy` listeners to each editor. I found it much simpler to attach listeners to the shared TextBuffer objects.

The package of each watched file has an `onDidDeactivate` listener attached. This allows us to stop watching the files of that package when/if the grammar is deactivated. This listener is reattached whenever the grammar is reloaded, because the `Package` object is recreated.

When a watched file is deleted, we stop watching it.

When a watched file is renamed, we stop watching it *if* the new file path does not match the `grammarRE` pattern. We assume its package is still the same, but maybe this isn't a safe assumption?

We *don't* yet listen for renamed package of watched files, but this could be a nice addition sometime in the future.

The buffer listeners are now properly disposed of when live reloading is disabled by the user.

The path of each `Package` is already resolved when it's a symlink, so `getPackageNameByFilePath` has been refactored and renamed to `resolvePackageName`. The function still looks at the `path` of
every active package until it finds a match, which I agree is better than assuming the package directory's basename is equal to its "name" field in `package.json`.

